### PR TITLE
Fix sitemap spider. Allow 404, 403 and 500 error code

### DIFF
--- a/backend/crawler/crawler/spiders/lucas_crawl_spider.py
+++ b/backend/crawler/crawler/spiders/lucas_crawl_spider.py
@@ -3,7 +3,7 @@ from scrapy.spiders import CrawlSpider, Rule
 
 class LucasCrawlSpider(CrawlSpider):
     name = "lucas_crawl_spider"
-    handle_httpstatus_list = [403, 404]
+    handle_httpstatus_list = [403, 404, 500]
 
     def __init__(self, *args, **kwargs):
         self.url = kwargs.get("url")

--- a/backend/crawler/crawler/spiders/lucas_personalised_crawl_spider.py
+++ b/backend/crawler/crawler/spiders/lucas_personalised_crawl_spider.py
@@ -5,7 +5,7 @@ from main.models import PersonalisedCrawl
 
 class LucasPersonalisedCrawlSpider(Spider):
     name = "lucas_personalised_crawl_spider"
-    handle_httpstatus_list = [403, 404]
+    handle_httpstatus_list = [403, 404, 500]
 
     def __init__(self, *args, **kwargs):
         personalised_crawl_id = kwargs.get("personalised_crawl_id")

--- a/backend/crawler/crawler/spiders/lucas_sitemap_spider.py
+++ b/backend/crawler/crawler/spiders/lucas_sitemap_spider.py
@@ -3,7 +3,7 @@ from scrapy.spiders import SitemapSpider
 
 class LucasSitemapSpider(SitemapSpider):
     name = "lucas_sitemap_spider"
-    handle_httpstatus_list = [403, 404]
+    handle_httpstatus_list = [403, 404, 500]
 
     def __init__(self, *args, **kwargs):
         self.sitemap_urls = kwargs.get("sitemap_urls")

--- a/frontend/src/lucas/crawl/crawlTable.jsx
+++ b/frontend/src/lucas/crawl/crawlTable.jsx
@@ -35,7 +35,7 @@ const CrawlTable = () => {
                 <TableHead>
                     <TableRow>
                         <TableCell>Address</TableCell>
-                        <TableCell align="left">Only status 200 for now :(</TableCell>
+                        <TableCell align="left">Status</TableCell>
                     </TableRow>
                 </TableHead>
                 <TableBody>


### PR DESCRIPTION
While looking through our spiders, I saw the sitemap one was hardcoded. We should allow it to take as arguments the sitemap urls and the sitemap_follow parameters.

Also, I added as options to crawl some others error codes. We should make this as customisable from the UI. 